### PR TITLE
fix: add spm support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,21 @@
+// swift-tools-version:5.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+import PackageDescription
+
+let package = Package(
+    name: "Mtribes",
+    platforms: [
+        .iOS(.v10),
+        .tvOS(.v10),
+        .macOS(.v10_12),
+        .watchOS(.v3),
+    ],
+    products: [
+        .library(
+            name: "Mtribes",
+            targets: ["Mtribes"]),
+    ],
+    targets: [
+        .binaryTarget(name: "Mtribes", path: "Mtribes.xcframework")
+    ]
+)


### PR DESCRIPTION
This PR adds SPM back into the repo. SPM support means we can use swift package manager to automatically donwload the dependency from github rather than having to do that through cocoa pods. It was previously added to this repository but then later removed due to these issues which have now been fixed:

- https://github.com/apple/swift/issues/56651
- https://github.com/apple/swift-package-manager/issues/4514